### PR TITLE
Configure hatch-vcs to avoid local version identifiers for PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,43 @@ The tool reads configuration from your `pyproject.toml` file and supports additi
 # Extra recipe sections
 ```
 
+## Releases and Contributing
+
+### Versioning and Releases
+
+This project uses `hatch-vcs` for automatic version management based on git tags:
+
+- **Development versions**: Generated automatically as `0.1.devN` (where N is the number of commits since the last tag)
+- **Release versions**: Created by pushing git tags in the format `v1.0.0`
+
+#### Creating a Release
+
+1. Create and push a git tag:
+
+   ```bash
+   git tag v1.0.0
+   git push origin v1.0.0
+   ```
+
+2. Create a GitHub release from the tag, which will automatically:
+   - Build the package
+   - Run all tests and checks
+   - Publish to PyPI
+   - Update the changelog
+
+#### Test Publishing
+
+For testing the publishing process, use the manual workflow dispatch in GitHub Actions, which publishes to Test PyPI with development versions.
+
+### Contributing
+
+1. Fork the repository
+2. Create a feature branch
+3. Make your changes
+4. Run tests: `pixi run test`
+5. Run checks: `pixi run check`
+6. Submit a pull request
+
 ## License
 
 This project is licensed under the MIT License - see the LICENSE file for details.

--- a/pixi.lock
+++ b/pixi.lock
@@ -3259,8 +3259,8 @@ packages:
   timestamp: 1733710122949
 - pypi: ./
   name: pyrattler-recipe-autogen
-  version: 0.1.dev32+g67b64e3dc.d20250818
-  sha256: 91a998f3ca1dabf825ee69e58e8fff38522dac49554628313ea1a7de02e515de
+  version: 0.1.dev34
+  sha256: dfc0419fda6f1554f640e3bcf3beb1b714bc813ce9be973a5d18b5125035cea5
   requires_dist:
   - pyyaml
   - tomli ; python_full_version < '3.11'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ include = [
 
 [tool.hatch.version]
 source = "vcs"
+raw-options = { local_scheme = "no-local-version" }
 
 [tool.hatch.build.hooks.vcs]
 version-file = "src/pyrattler_recipe_autogen/_version.py"


### PR DESCRIPTION
- Set local_scheme = 'no-local-version' in hatch.version configuration
- This ensures development versions are generated as '0.1.devN' instead of '0.1.devN+gHASH'
- PyPI does not allow local version identifiers (the +gHASH part)
- Successful test upload to Test PyPI with version 0.1.dev34
- Add documentation about versioning and release process
- Fix duplicate markdown headings